### PR TITLE
Use setImmediate

### DIFF
--- a/lib/ccznp.js
+++ b/lib/ccznp.js
@@ -304,7 +304,7 @@ CcZnp.prototype._scheduleNextSend = function () {
     var txQueue = this._txQueue;
 
     if (txQueue.length) {
-        process.nextTick(function () {
+        setImmediate(function () {
             txQueue.shift()();
         });
     }
@@ -329,7 +329,7 @@ CcZnp.prototype._parseMtIncomingData = function (data) {
         argObj.parse(data.type, data.len, data.payload, function (err, result) {
             data.payload = result;
 
-            process.nextTick(function () {
+            setImmediate(function () {
                 self._mtIncomingDataHdlr(err, data);
             });
         });


### PR DESCRIPTION
Give all IO a chance to be executed, don't jump the queue.