### PR TITLE
Remove `console.log` statement

### DIFF
--- a/lib/ccznp.js
+++ b/lib/ccznp.js
@@ -329,7 +329,6 @@ CcZnp.prototype._parseMtIncomingData = function (data) {
 
         argObj.parse(data.type, data.len, data.payload, function (err, result) {
             data.payload = result;
-console.log(data);
             setImmediate(function () {
                 self._mtIncomingDataHdlr(err, data);
             });


### PR DESCRIPTION
This was (inadvertently?) introduced in
commit 68d57b6f00be88db31824675e48797faebee1ceb